### PR TITLE
Replaced yasp.co with opendota.com

### DIFF
--- a/data/sandbox_webpermissions.json
+++ b/data/sandbox_webpermissions.json
@@ -14,7 +14,7 @@
         "https?:\\/\\/fanyi\\.youdao\\.com\\/.*",
         "https?:\\/\\/translate\\.google\\.com\\/.*",
         "https?:\\/\\/(www\\.)?dotabuff\\.com\\/.*",
-        "https?:\\/\\/(www\\.)?yasp\\.co\\/.*"
+        "https?:\\/\\/(www|api)\\.opendota\\.com\\/.*"
     ]
 }
 


### PR DESCRIPTION
The domain changed from yasp to opendota.